### PR TITLE
Add support for darwin ARM cores

### DIFF
--- a/cpu_cores/darwin.py
+++ b/cpu_cores/darwin.py
@@ -27,9 +27,11 @@ class DarwinCPUCoresCounter(CPUCoresCounter):
             for line in lines:
                 tmp = line.strip()
                 if tmp.startswith(b'Total Number of Cores:'):
-                    self._physical_cores_count = int(tmp.split(b':')[1])
-                if tmp.startswith(b'Number of Processors:'):
+                    tmp = int(tmp.split(b':')[1].split(b'(')[0])
+                    self._physical_cores_count = tmp
+                elif tmp.startswith(b'Number of Processors:'):
                     self._physical_processors_count = int(tmp.split(b':')[1])
-        if self._physical_processors_count is None or \
-                self._physical_cores_count is None:
+        if self._physical_cores_count is None:
             raise Exception('impossible to get the cpu cores count (darwin)')
+        if self._physical_processors_count is None:
+            self._physical_processors_count = 1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 -r pip-requirements.txt
 
-nose==1.2.1
+nose==1.3.7
 coverage==3.6

--- a/tests/darwin2
+++ b/tests/darwin2
@@ -1,0 +1,16 @@
+Hardware:
+
+    Hardware Overview:
+
+      Model Name: MacBook Pro
+      Model Identifier: MacBookPro18,4
+      Chip: Apple M1 Max
+      Total Number of Cores: 10 (8 performance and 2 efficiency)
+      Memory: 64 GB
+      System Firmware Version: 7429.41.5
+      OS Loader Version: 7429.41.5
+      Serial Number (system): Y0XXXXXXXX
+      Hardware UUID: FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF
+      Provisioning UDID: 00006001-FFFFFFFFFFFFFFFF
+      Activation Lock Status: Disabled
+

--- a/tests/test_darwin.py
+++ b/tests/test_darwin.py
@@ -31,6 +31,11 @@ class TestCPUCores(unittest.TestCase):
         self.assertEqual(x._physical_cores_count, 2)
         self.assertEqual(x._physical_processors_count, 1)
 
+    def test_darwin_count2(self):
+        x = self._test_darwin_count()
+        x._count('cat %s' % os.path.join(self._dir(), 'darwin2'))
+        self.assertEqual(x._physical_cores_count, 10)
+        self.assertEqual(x._physical_processors_count, 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
ARM powered Macs do have a heterogenous architecture. This breaks the current
parsing logic, as both performance and efficency cores are reported now.
Additionally system_profiler does not seem to output 'Number of Processors:'
anymore, therefore assume 1 if 'Total Number of Cores:' is present.

darwin2 testcase is a redacted sample output for a M1 Machine, which broke
before this patch.

nose is bumped for python3 support, tests would not run otherwise.

Overall this is really a minimum effort fix, feel free to implement something more clever or discard it entirely. Only stumbled across this as it is used in blender-benchmark-script.