### PR TITLE
Handle M1 chips

### DIFF
--- a/cpu_cores/darwin.py
+++ b/cpu_cores/darwin.py
@@ -27,9 +27,12 @@ class DarwinCPUCoresCounter(CPUCoresCounter):
             for line in lines:
                 tmp = line.strip()
                 if tmp.startswith(b'Total Number of Cores:'):
-                    self._physical_cores_count = int(tmp.split(b':')[1])
+                    self._physical_cores_count = int(tmp.split(b':')[1].decode('utf-8').split('(')[0].replace(' ',''))
                 if tmp.startswith(b'Number of Processors:'):
                     self._physical_processors_count = int(tmp.split(b':')[1])
+                if tmp.startswith(b'Chip:'):
+                    if b"Apple M" in tmp:
+                        self._physical_processors_count = 1
         if self._physical_processors_count is None or \
                 self._physical_cores_count is None:
             raise Exception('impossible to get the cpu cores count (darwin)')


### PR DESCRIPTION
Output of */usr/sbin/system_profiler -detailLevel full SPHardwareDataType* on arm Mac is something like
```
Model Name: MacBook Air
      Model Identifier: MacBookAir10,1
      Chip: Apple M1
      Total Number of Cores: 8 (4 performance and 4 efficiency)
      Memory: 8 GB
```

this PR handles the "(" in *Total Number of Cores* and the Chip line